### PR TITLE
Resolve Tileserver error

### DIFF
--- a/ui/RightScreen/RightScreen.qml
+++ b/ui/RightScreen/RightScreen.qml
@@ -16,6 +16,14 @@ Rectangle {
     Plugin {
         id: mapPlugin
         name: "osm"
+        PluginParameter {
+            name: "osm.mapping.providersrepository.disabled"
+            value: "true"
+        }
+        PluginParameter {
+            name: "osm.mapping.providersrepository.address"
+            value: "http://maps-redirect.qt.io/osm/5.6/"
+        }
     }
 
     Map {


### PR DESCRIPTION
This resolves the following error, which caused error with map:
- QGeoTileProviderOsm: Tileserver disabled at  QUrl("http://maps-redirect.qt.io/osm/5.8/satellite")

Reference: https://forum.qt.io/topic/118089/error-when-running-minimal-map-example/3

Signed-off-by: Hyun Sik Yoon (Eric Yoon) <hyunsik.yoon.1024@gmail.com>